### PR TITLE
Fix brightness and volume slider

### DIFF
--- a/src/screens/anime/watch/hooks/use-brightness-gesture.ts
+++ b/src/screens/anime/watch/hooks/use-brightness-gesture.ts
@@ -13,6 +13,7 @@ const clamp = (value: number, min: number, max: number) => {
 
 const WIDTH_PERCENT = 0.6;
 const HEIGHT_PERCENT = 0.85;
+const MIN_DISTANCE = 20;
 
 const useBrightnessGesture = () => {
   const brightnessSlider = useAtomValue(brightnessSliderAtom);
@@ -27,6 +28,7 @@ const useBrightnessGesture = () => {
     moveTouchY: 0,
     finalValue: 1,
     isShown: false,
+    initialY: NaN,
   });
 
   const brightnessPan = Gesture.Pan()
@@ -34,11 +36,13 @@ const useBrightnessGesture = () => {
       const initialBrightness = brightnessSlider.getBrightness();
 
       refs.value.actualInitialBrightness = initialBrightness;
+      refs.value.initialY = NaN;
 
       if (event.x > screenSize.width - screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
       if (event.y > screenSize.height * HEIGHT_PERCENT) return;
 
+      refs.value.initialY = event.y;
       refs.value.sliderHeight = brightnessSlider.getHeight();
       refs.value.baseValue = event.y;
       refs.value.initialBrightness = initialBrightness;
@@ -49,6 +53,11 @@ const useBrightnessGesture = () => {
       if (event.x > screenSize.width - screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
       if (event.y > screenSize.height * HEIGHT_PERCENT) return;
+      if (
+        isNaN(refs.value.initialY) ||
+        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+      )
+        return;
 
       if (!refs.value.isShown) {
         brightnessSlider.show();
@@ -83,16 +92,22 @@ const useBrightnessGesture = () => {
 
       brightnessSlider.setAnimationValue(refs.value.finalValue);
     })
-    .onFinalize(() => {
-      if (refs.value.finalValue !== refs.value.actualInitialBrightness) {
-        runOnJS(brightnessSlider.setBrightness)(refs.value.finalValue);
-      }
-
+    .onFinalize((event) => {
       brightnessSlider.hide();
 
       refs.value.isShown = false;
+
+      if (
+        isNaN(refs.value.initialY) ||
+        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+      )
+        return;
+
+      if (refs.value.finalValue !== refs.value.actualInitialBrightness) {
+        runOnJS(brightnessSlider.setBrightness)(refs.value.finalValue);
+      }
     })
-    .minDistance(20);
+    .minDistance(MIN_DISTANCE);
 
   return brightnessPan;
 };

--- a/src/screens/anime/watch/hooks/use-brightness-gesture.ts
+++ b/src/screens/anime/watch/hooks/use-brightness-gesture.ts
@@ -29,6 +29,7 @@ const useBrightnessGesture = () => {
     finalValue: 1,
     isShown: false,
     initialY: NaN,
+    shouldMoveFreely: false,
   });
 
   const brightnessPan = Gesture.Pan()
@@ -37,6 +38,7 @@ const useBrightnessGesture = () => {
 
       refs.value.actualInitialBrightness = initialBrightness;
       refs.value.initialY = NaN;
+      refs.value.shouldMoveFreely = false;
 
       if (event.x > screenSize.width - screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
@@ -53,11 +55,16 @@ const useBrightnessGesture = () => {
       if (event.x > screenSize.width - screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
       if (event.y > screenSize.height * HEIGHT_PERCENT) return;
-      if (
-        isNaN(refs.value.initialY) ||
-        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
-      )
-        return;
+
+      if (!refs.value.shouldMoveFreely) {
+        if (
+          isNaN(refs.value.initialY) ||
+          Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+        )
+          return;
+      }
+
+      refs.value.shouldMoveFreely = true;
 
       if (!refs.value.isShown) {
         brightnessSlider.show();
@@ -97,11 +104,13 @@ const useBrightnessGesture = () => {
 
       refs.value.isShown = false;
 
-      if (
-        isNaN(refs.value.initialY) ||
-        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
-      )
-        return;
+      if (!refs.value.shouldMoveFreely) {
+        if (
+          isNaN(refs.value.initialY) ||
+          Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+        )
+          return;
+      }
 
       if (refs.value.finalValue !== refs.value.actualInitialBrightness) {
         runOnJS(brightnessSlider.setBrightness)(refs.value.finalValue);

--- a/src/screens/anime/watch/hooks/use-volume-gesture.ts
+++ b/src/screens/anime/watch/hooks/use-volume-gesture.ts
@@ -29,6 +29,7 @@ const useVolumeGesture = () => {
     finalValue: 1,
     isShown: false,
     initialY: NaN,
+    shouldMoveFreely: false,
   });
 
   const volumePan = Gesture.Pan()
@@ -37,6 +38,7 @@ const useVolumeGesture = () => {
 
       refs.value.actualInitialVolume = initialVolume;
       refs.value.initialY = NaN;
+      refs.value.shouldMoveFreely = false;
 
       if (event.x < screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
@@ -52,11 +54,16 @@ const useVolumeGesture = () => {
       if (event.x < screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
       if (event.y > screenSize.height * HEIGHT_PERCENT) return;
-      if (
-        isNaN(refs.value.initialY) ||
-        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
-      )
-        return;
+
+      if (!refs.value.shouldMoveFreely) {
+        if (
+          isNaN(refs.value.initialY) ||
+          Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+        )
+          return;
+      }
+
+      refs.value.shouldMoveFreely = true;
 
       if (!refs.value.isShown) {
         volumeSlider.show();
@@ -90,11 +97,13 @@ const useVolumeGesture = () => {
 
       refs.value.isShown = false;
 
-      if (
-        isNaN(refs.value.initialY) ||
-        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
-      )
-        return;
+      if (!refs.value.shouldMoveFreely) {
+        if (
+          isNaN(refs.value.initialY) ||
+          Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+        )
+          return;
+      }
 
       if (refs.value.finalValue !== refs.value.actualInitialVolume) {
         runOnJS(volumeSlider.setVolume)(refs.value.finalValue);

--- a/src/screens/anime/watch/hooks/use-volume-gesture.ts
+++ b/src/screens/anime/watch/hooks/use-volume-gesture.ts
@@ -13,6 +13,7 @@ const clamp = (value: number, min: number, max: number) => {
 
 const WIDTH_PERCENT = 0.6;
 const HEIGHT_PERCENT = 0.85;
+const MIN_DISTANCE = 20;
 
 const useVolumeGesture = () => {
   const volumeSlider = useAtomValue(volumeSliderAtom);
@@ -27,6 +28,7 @@ const useVolumeGesture = () => {
     moveTouchY: 0,
     finalValue: 1,
     isShown: false,
+    initialY: NaN,
   });
 
   const volumePan = Gesture.Pan()
@@ -34,11 +36,13 @@ const useVolumeGesture = () => {
       const initialVolume = volumeSlider.getVolume() ?? 1;
 
       refs.value.actualInitialVolume = initialVolume;
+      refs.value.initialY = NaN;
 
       if (event.x < screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
       if (event.y > screenSize.height * HEIGHT_PERCENT) return;
 
+      refs.value.initialY = event.y;
       refs.value.sliderHeight = volumeSlider.getHeight();
       refs.value.baseValue = event.y;
       refs.value.initialVolume = initialVolume;
@@ -48,6 +52,11 @@ const useVolumeGesture = () => {
       if (event.x < screenSize.width * WIDTH_PERCENT) return;
       if (event.y < screenSize.height * (1 - HEIGHT_PERCENT)) return;
       if (event.y > screenSize.height * HEIGHT_PERCENT) return;
+      if (
+        isNaN(refs.value.initialY) ||
+        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+      )
+        return;
 
       if (!refs.value.isShown) {
         volumeSlider.show();
@@ -76,16 +85,22 @@ const useVolumeGesture = () => {
 
       volumeSlider.setAnimationValue(refs.value.finalValue);
     })
-    .onFinalize(() => {
-      if (refs.value.finalValue !== refs.value.actualInitialVolume) {
-        runOnJS(volumeSlider.setVolume)(refs.value.finalValue);
-      }
-
+    .onFinalize((event) => {
       volumeSlider.hide();
 
       refs.value.isShown = false;
+
+      if (
+        isNaN(refs.value.initialY) ||
+        Math.abs(event.y - refs.value.initialY) < MIN_DISTANCE
+      )
+        return;
+
+      if (refs.value.finalValue !== refs.value.actualInitialVolume) {
+        runOnJS(volumeSlider.setVolume)(refs.value.finalValue);
+      }
     })
-    .minDistance(20);
+    .minDistance(MIN_DISTANCE);
 
   return volumePan;
 };


### PR DESCRIPTION
Because the slider gesture doesn't check if the user has moved their finger inside active area for at least 20px. The brightness keep being set to `1` everytime the user tap on the screen. 

This fixed this by checking if the user has moved inside the active area for at least 20px.